### PR TITLE
Add msg about long download time; avoid YAML load warning

### DIFF
--- a/redfish-uri-validator.py
+++ b/redfish-uri-validator.py
@@ -43,7 +43,7 @@ def run_test( user, password, rhost, openapi ):
     print( "Opening {}...".format( openapi ) )
     try:
         with open( openapi ) as openapi_file:
-            openapi_data = yaml.load( openapi_file )
+            openapi_data = yaml.load(openapi_file, Loader=yaml.FullLoader)
     except:
         print( "ERROR: Could not open {}".format( openapi ) )
         return None
@@ -60,8 +60,9 @@ def run_test( user, password, rhost, openapi ):
     if os.path.isdir( cachedir ):
         RMCOBJ.logout
 
-    # Login into the server and create a session
-    print( "Logging in to {}...".format( rhost ) )
+    # Login into the server, create a session, and download all resources
+    print("Service URI: {}".format(rhost))
+    print("Logging in and downloading resources; this may take a while...")
     try:
         RMCOBJ.login( base_url = rhost, username = user, password = password )
     except:


### PR DESCRIPTION
Added text in status message to indicate that the download of resources  may take a while.

Before:

```
Logging in to http://127.0.0.1:8007...
```

After:

```
Service URI: http://127.0.0.1:8007
Logging in and downloading resources; this may take a while...
```

Also added explicit `Loader=` param in call to `yaml.load()` to avoid deprecation warning.

Fixes #3 